### PR TITLE
Stripping new lines not preceded by a period from pasted text (fix fo…

### DIFF
--- a/src/admin/src/components/forms/office.js
+++ b/src/admin/src/components/forms/office.js
@@ -70,12 +70,18 @@ export const OfficeForm = ({ selected, onSave, onCancel }) => {
 			.pop();
 	};
 
-	useEffect(() => {
-		console.log("Office", office);
-	}, [office]);
-
 	const update = (field, value) => {
+		// value = value.replace(/(?<!\.|\?)([\r|\n])+([^?\.]+)/gm, "");
 		setOffice({ ...office, [field]: value });
+	};
+
+	const format = (field, e) => {
+		e.preventDefault();
+
+		let value = (e.clipboardData || window.clipboardData).getData("text");
+		let formatted = value.replace(/(?<!\.|\?|\n)([\r|\n])+([^?\.]+)/gm, "");
+
+		setOffice({ ...office, [field]: formatted });
 	};
 
 	const updateIncumbent = (term, field, value) => {
@@ -143,6 +149,9 @@ export const OfficeForm = ({ selected, onSave, onCancel }) => {
 						rows="5"
 						onInput={(e) => {
 							update("description", e.target.value);
+						}}
+						onPaste={(e) => {
+							format("description", e);
 						}}
 					></textarea>
 				</div>


### PR DESCRIPTION
Fix #13 

This is actually a more complicated problem than it seems. If you look at the "City Councilors District Members" in Worcester you can see an example. The issue was that there were line breaks in the middle of lines when copied from the PDF, and we don't want to just strip out all new lines. What I'm doing instead is just using some regex on the 'paste' event to strip out new lines not preceded by either a question mark, period, or another new line. 

It probably won't work in all cases, but that should cover most pasted formatting issues. 