### PR TITLE
Support showing example town & its notes

### DIFF
--- a/src/admin/src/api-hooks.js
+++ b/src/admin/src/api-hooks.js
@@ -99,21 +99,21 @@ export const useMunicipality = (municipality_id) =>
   useQuery({
     queryKey: ["municipalities", municipality_id],
     queryFn: () => getMunicipality(municipality_id),
-    enabled: !!municipality_id,
+    enabled: municipality_id !== undefined,
   });
 
 export const useMunicipalityOffices = (municipality_id) =>
   useQuery({
     queryKey: ["municipalities", municipality_id, "offices"],
     queryFn: () => getMunicipalityOffices(municipality_id),
-    enabled: !!municipality_id,
+    enabled: municipality_id !== undefined,
   });
 
 export const useMunicipalityElections = (municipality_id) =>
   useQuery({
     queryKey: ["municipalities", municipality_id, "elections"],
     queryFn: () => getMunicipalityElections(municipality_id),
-    enabled: !!municipality_id,
+    enabled: municipality_id !== undefined,
   });
 
 export const useMunicipalityCollections = (municipality_id) =>

--- a/src/admin/src/api-hooks.js
+++ b/src/admin/src/api-hooks.js
@@ -120,7 +120,7 @@ export const useMunicipalityCollections = (municipality_id) =>
   useQuery({
     queryKey: ["municipalities", municipality_id, "collections"],
     queryFn: () => getMunicipalityCollections(municipality_id),
-    enabled: !!municipality_id,
+    enabled: municipality_id !== undefined,
   });
 
 export const invalidateMunicipality = (municipality_id) => {

--- a/src/node-api/src/controllers/municipality.controller.js
+++ b/src/node-api/src/controllers/municipality.controller.js
@@ -17,6 +17,9 @@ let municipalityController = {
   list: async (req, res, next) => {
     const municipalities = await Municipality.findAll({
       include: [{ model: Contact, as: "contacts" }],
+      order: [
+        ["id", "ASC"],
+      ],
     });
 
     return res.status(200).json(municipalities);


### PR DESCRIPTION
First, I'm going to run the following in my terminal to connect to our production db and then enter the user password. I'll get the values for `HOST`, `DATABASE`, `USER`, and the password from the Secrets Manager in AWS.
```
 psql -h HOST -d DATABASE -U USER 
```

Then I will insert an example town with a contact and note.
```
INSERT INTO municipality (id,name,type,website,slug) VALUES (0,'Example Town','TOWN','www.exampletown.com','example_town');
INSERT INTO contact (municipality_id,name,title,phone,email) VALUES (0,'Example Clerk','Town Clerk','555-555-5555','example@clerk.com');
INSERT INTO note (item_id,item_type,summary,content) VALUES (0,'municipality','This is an example town','Can also be used by developers and beta users for testing');
```

Finally, I'll merge & deploy this code so that the town will appear at the top of the list, and its related content will show